### PR TITLE
Fix rescheduling logic and revision handling

### DIFF
--- a/services/ai-schedule-service/src/services/schedulingEngine.ts
+++ b/services/ai-schedule-service/src/services/schedulingEngine.ts
@@ -14,6 +14,7 @@ export interface TopicEstimate {
   subject: string;
   estimatedHours: number;
   difficulty: 'easy' | 'medium' | 'hard';
+  generateRevisions?: boolean; // Default true. If false, no revisions generated.
 }
 
 export interface NormalizedTopic extends TopicEstimate {
@@ -96,6 +97,9 @@ const REVISION_INTERVALS = [3, 7, 14];
 
 /** Revision sessions are 25% of the original topic duration */
 const REVISION_DURATION_RATIO = 0.25;
+
+/** Max days to look ahead for a revision slot if the target day is full */
+const REVISION_LOOKAHEAD_DAYS = 3;
 
 // ─── Core Functions ─────────────────────────────────────────────────
 
@@ -266,6 +270,8 @@ export function generateTimeBlocks(
  * Revision duration = 25% of original topic minutes.
  * Sessions are appended to the target day if capacity allows.
  * If revision day exceeds targetCompletionDate, it is skipped.
+ *
+ * UPDATE: If target day is full, search up to REVISION_LOOKAHEAD_DAYS forward.
  */
 export function insertRevisionSessions(
   days: DayPlan[],
@@ -287,40 +293,55 @@ export function insertRevisionSessions(
     const topic = topicMap.get(topicName);
     if (!topic) continue;
 
+    // Respect flag to skip revision generation
+    if (topic.generateRevisions === false) continue;
+
     const revisionMinutes = Math.max(
       MIN_SESSION_MINUTES,
       Math.round(topic.totalMinutes * REVISION_DURATION_RATIO)
     );
 
     for (const interval of REVISION_INTERVALS) {
-      const revDay = completionDay + interval;
-      if (revDay >= result.length) continue; // past exam date
+      let inserted = false;
 
-      // Check if there's capacity on that day
-      const dayPlan = result[revDay];
-      if (dayPlan.totalMinutes + revisionMinutes > dailyAvailableMinutes) {
-        continue; // skip if day is too full
+      // Try target day and a few days forward
+      for (let offset = 0; offset <= REVISION_LOOKAHEAD_DAYS; offset++) {
+        const revDay = completionDay + interval + offset;
+
+        if (revDay >= result.length) break; // past exam date, stop trying for this interval
+
+        const dayPlan = result[revDay];
+
+        // Check capacity
+        if (dayPlan.totalMinutes + revisionMinutes <= dailyAvailableMinutes) {
+          // Found a slot!
+
+          // Find end time of last block on that day
+          let startMinute: number;
+          if (dayPlan.blocks.length > 0) {
+            const lastBlock = dayPlan.blocks[dayPlan.blocks.length - 1];
+            startMinute = hhmmToMinutes(lastBlock.endTime) + BREAK_MINUTES;
+          } else {
+            const [h, m] = preferredStartTime.split(':').map(Number);
+            startMinute = h * 60 + m;
+          }
+
+          dayPlan.blocks.push({
+            topic: topicName,
+            subject: topic.subject,
+            startTime: minutesToHHMM(startMinute),
+            endTime: minutesToHHMM(startMinute + revisionMinutes),
+            plannedMinutes: revisionMinutes,
+            isRevision: true,
+          });
+          dayPlan.totalMinutes += revisionMinutes;
+          inserted = true;
+          break; // Stop looking for a slot for this interval
+        }
       }
 
-      // Find end time of last block on that day
-      let startMinute: number;
-      if (dayPlan.blocks.length > 0) {
-        const lastBlock = dayPlan.blocks[dayPlan.blocks.length - 1];
-        startMinute = hhmmToMinutes(lastBlock.endTime) + BREAK_MINUTES;
-      } else {
-        const [h, m] = preferredStartTime.split(':').map(Number);
-        startMinute = h * 60 + m;
-      }
-
-      dayPlan.blocks.push({
-        topic: topicName,
-        subject: topic.subject,
-        startTime: minutesToHHMM(startMinute),
-        endTime: minutesToHHMM(startMinute + revisionMinutes),
-        plannedMinutes: revisionMinutes,
-        isRevision: true,
-      });
-      dayPlan.totalMinutes += revisionMinutes;
+      // If !inserted, it means we couldn't fit it within the lookahead window.
+      // We silently skip it (best effort for MVP).
     }
   }
 

--- a/services/ai-schedule-service/src/services/studyPlanService.ts
+++ b/services/ai-schedule-service/src/services/studyPlanService.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, StudySession, StudyPlan } from "@prisma/client";
 import { AIAPIClient } from './ai-api-client';
 import { createLogger } from "../utils/logger";
 import { prisma } from '../config/database';
@@ -41,39 +41,6 @@ export interface CoverageAnalytics {
   daysRemaining: number;
   remainingWorkloadMinutes: number;
   isAtRisk: boolean;
-}
-
-// ─── Local Type Extensions (Until prisma generate runs) ──────────────────
-
-interface ExtendedStudySession {
-  id: string;
-  studyPlanId: string;
-  date: Date;
-  topic: string;
-  startTime: string;
-  endTime: string;
-  plannedMinutes: number;
-  completedMinutes: number | null;
-  isRevision: boolean;
-  status: string;
-  remarks: string | null;
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-interface ExtendedStudyPlan {
-  id: string;
-  userId: string;
-  examName: string | null;
-  subjects: string[];
-  availableHoursPerDay: number;
-  preferredStartTime: string;
-  targetCompletionDate: Date;
-  plan: any;
-  isActive: boolean;
-  createdAt: Date;
-  updatedAt: Date;
-  sessions: ExtendedStudySession[];
 }
 
 // ─── Service Class ──────────────────────────────────────────────────
@@ -135,7 +102,6 @@ export class StudyPlanService {
     // Step 3: Persist everything in a transaction
     const studyPlan = await this.prisma.$transaction(async (tx) => {
       // Create the study plan
-      // Cast to any because Prisma types are outdated (missing examName, preferredStartTime, etc.)
       const plan = await tx.studyPlan.create({
         data: {
           userId: data.userId,
@@ -146,14 +112,13 @@ export class StudyPlanService {
           targetCompletionDate: targetDate,
           plan: this.scheduleResultToJson(scheduleResult),
           isActive: true,
-        } as any,
+        },
       });
 
       // Bulk-create sessions
       const sessionData = this.scheduleResultToSessions(plan.id, scheduleResult);
       if (sessionData.length > 0) {
-        // Cast to any because Prisma types don't know about plannedMinutes/isRevision yet
-        await tx.studySession.createMany({ data: sessionData as any });
+        await tx.studySession.createMany({ data: sessionData });
       }
 
       return plan;
@@ -178,14 +143,14 @@ export class StudyPlanService {
     const studyPlan = await this.prisma.studyPlan.findUnique({
       where: { id },
       include: { sessions: { orderBy: { date: 'asc' } } },
-    }) as unknown as ExtendedStudyPlan | null;
+    });
 
     if (!studyPlan) return null;
 
     return {
       planId: studyPlan.id,
       userId: studyPlan.userId,
-      examName: studyPlan.examName || undefined, // Handle null vs undefined mismatch if any
+      examName: studyPlan.examName || undefined,
       subjects: studyPlan.subjects,
       availableHoursPerDay: studyPlan.availableHoursPerDay,
       preferredStartTime: studyPlan.preferredStartTime,
@@ -202,10 +167,10 @@ export class StudyPlanService {
 
   async getAllPlans(userId: string) {
     return this.prisma.studyPlan.findMany({
-      where: { userId, isActive: true } as any, // Cast for isActive
+      where: { userId, isActive: true },
       include: { sessions: { orderBy: { date: 'asc' } } },
       orderBy: { createdAt: 'desc' },
-    }) as unknown as Promise<ExtendedStudyPlan[]>;
+    });
   }
 
   // ─── UPDATE PLAN ────────────────────────────────────────────────
@@ -221,7 +186,7 @@ export class StudyPlanService {
         ...(updateData.targetCompletionDate && {
           targetCompletionDate: new Date(updateData.targetCompletionDate),
         }),
-      } as any,
+      },
     });
 
     return studyPlan;
@@ -231,8 +196,8 @@ export class StudyPlanService {
 
   async deletePlanById(id: string): Promise<boolean> {
     await this.prisma.$transaction(async (tx) => {
-      await tx.studySession.deleteMany({ where: { studyPlanId: id } } as any);
-      await tx.studyPlan.delete({ where: { id } } as any);
+      await tx.studySession.deleteMany({ where: { studyPlanId: id } });
+      await tx.studyPlan.delete({ where: { id } });
     });
     return true;
   }
@@ -242,7 +207,7 @@ export class StudyPlanService {
   async deactivatePlan(id: string): Promise<void> {
     await this.prisma.studyPlan.update({
       where: { id },
-      data: { isActive: false } as any,
+      data: { isActive: false },
     });
   }
 
@@ -269,8 +234,8 @@ export class StudyPlanService {
         status,
         ...(completedMinutes !== undefined && { completedMinutes }),
         ...(remarks !== undefined && { remarks }),
-      } as any,
-    }) as unknown as ExtendedStudySession;
+      },
+    });
 
     // Trigger async rescheduling for skipped or partial sessions
     if (status === 'skipped' || status === 'partial') {
@@ -312,7 +277,7 @@ export class StudyPlanService {
     const plan = await this.prisma.studyPlan.findUnique({
       where: { id: studyPlanId },
       include: { sessions: true },
-    }) as unknown as ExtendedStudyPlan | null;
+    });
 
     if (!plan) throw new Error(`Study plan not found: ${studyPlanId}`);
     if (!plan.isActive) throw new Error(`Study plan is deactivated: ${studyPlanId}`);
@@ -323,13 +288,13 @@ export class StudyPlanService {
     ));
 
     // Compute remaining workload from incomplete sessions
-    const allSessions = plan.sessions as unknown as ExtendedStudySession[];
     let remainingMinutes = 0;
 
-    // Collect topics that still need work
-    const topicRemainingMinutes = new Map<string, { minutes: number; subject: string }>();
+    // Collect topics that still need work, separated by type
+    // Map<topicName, { studyMinutes, revisionMinutes, subject }>
+    const topicWorkload = new Map<string, { studyMinutes: number; revisionMinutes: number; subject: string }>();
 
-    for (const session of allSessions) {
+    for (const session of plan.sessions) {
       if (session.status === 'completed') continue;
 
       // For skipped/pending/partial sessions
@@ -346,11 +311,16 @@ export class StudyPlanService {
       
       if (unfinishedMinutes <= 0) continue;
 
-      const existing = topicRemainingMinutes.get(session.topic) || { minutes: 0, subject: '' };
-      topicRemainingMinutes.set(session.topic, {
-        minutes: existing.minutes + unfinishedMinutes,
-        subject: existing.subject || session.topic, // best effort subject
-      });
+      const existing = topicWorkload.get(session.topic) || { studyMinutes: 0, revisionMinutes: 0, subject: '' };
+
+      if (session.isRevision) {
+        existing.revisionMinutes += unfinishedMinutes;
+      } else {
+        existing.studyMinutes += unfinishedMinutes;
+      }
+      existing.subject = existing.subject || session.topic; // best effort subject
+
+      topicWorkload.set(session.topic, existing);
       remainingMinutes += unfinishedMinutes;
     }
 
@@ -361,13 +331,29 @@ export class StudyPlanService {
 
     // Build topic estimates from remaining workload
     const rescheduledTopics: TopicEstimate[] = [];
-    for (const [topicName, data] of topicRemainingMinutes) {
-      rescheduledTopics.push({
-        name: topicName,
-        subject: data.subject,
-        estimatedHours: data.minutes / 60,
-        difficulty: 'medium', // default for rescheduling
-      });
+
+    for (const [topicName, data] of topicWorkload) {
+      // 1. Core study workload (generates new revisions)
+      if (data.studyMinutes > 0) {
+        rescheduledTopics.push({
+          name: topicName,
+          subject: data.subject,
+          estimatedHours: data.studyMinutes / 60,
+          difficulty: 'medium', // difficulty lost, default to medium
+          generateRevisions: true,
+        });
+      }
+
+      // 2. Revision catch-up workload (does NOT generate new revisions)
+      if (data.revisionMinutes > 0) {
+        rescheduledTopics.push({
+          name: `${topicName} (Revision)`,
+          subject: data.subject,
+          estimatedHours: data.revisionMinutes / 60,
+          difficulty: 'medium',
+          generateRevisions: false,
+        });
+      }
     }
 
     // Generate new schedule from tomorrow onwards
@@ -389,19 +375,19 @@ export class StudyPlanService {
         where: {
           studyPlanId,
           date: { gte: tomorrowMidnight },
-        } as any, // Cast because old types don't support date queries this way correctly
+        },
       });
 
       // Insert new sessions
       const sessionData = this.scheduleResultToSessions(studyPlanId, scheduleResult);
       if (sessionData.length > 0) {
-        await tx.studySession.createMany({ data: sessionData as any });
+        await tx.studySession.createMany({ data: sessionData });
       }
 
       // Update the plan snapshot
       await tx.studyPlan.update({
         where: { id: studyPlanId },
-        data: { plan: this.scheduleResultToJson(scheduleResult) } as any,
+        data: { plan: this.scheduleResultToJson(scheduleResult) },
       });
     });
 
@@ -418,7 +404,7 @@ export class StudyPlanService {
     const plan = await this.prisma.studyPlan.findUnique({
       where: { id: studyPlanId },
       include: { sessions: true },
-    }) as unknown as ExtendedStudyPlan | null;
+    });
 
     if (!plan) throw new Error(`Study plan not found: ${studyPlanId}`);
 
@@ -434,9 +420,7 @@ export class StudyPlanService {
     let totalPlannedMinutes = 0;
     let totalCompletedMinutes = 0;
 
-    // Use any because TypeScript thinks plan.sessions is old StudySession[]
-    // but at runtime it has plannedMinutes, completedMinutes, status, etc.
-    for (const session of (plan.sessions as unknown as ExtendedStudySession[])) {
+    for (const session of plan.sessions) {
       totalPlannedMinutes += session.plannedMinutes;
 
       switch (session.status) {


### PR DESCRIPTION
### **User description**
This PR fixes critical issues in the deterministic scheduling engine and rescheduling logic.

1.  **Revision Explosion:** Previously, rescheduling a plan with pending/skipped revisions would treat those revisions as new "topics", generating *new* revisions for them, leading to an exponential increase in workload. This is fixed by distinguishing between "study" workload (which generates revisions) and "revision" workload (which does not).
2.  **Day Full / Skipped Revisions:** Previously, if a day was fully booked with new topics, revisions scheduled for that day (e.g., D+3) were silently skipped. The new logic implements a lookahead search (up to 3 days) to find the nearest available slot.
3.  **Type Safety:** Removed `as any` casts in `StudyPlanService` and utilized generated Prisma types for better type safety and maintainability.

---
*PR created automatically by Jules for task [15655965474077993711](https://jules.google.com/task/15655965474077993711) started by @GauravSharmaCode*


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix revision explosion by distinguishing study workload from revision workload with `generateRevisions` flag

- Implement lookahead search (up to 3 days) to find available slots when target day is full

- Separate pending/skipped revisions from new study topics during rescheduling

- Remove `as any` casts and use proper Prisma-generated types for type safety


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Rescheduling Triggered"] --> B["Separate Study vs Revision Workload"]
  B --> C["Study Workload<br/>generateRevisions: true"]
  B --> D["Revision Workload<br/>generateRevisions: false"]
  C --> E["Generate New Revisions"]
  D --> F["No New Revisions"]
  E --> G["Insert Sessions with Lookahead"]
  F --> G
  G --> H["Find Available Slot<br/>within 3 Days"]
  H --> I["Updated Schedule"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schedulingEngine.ts</strong><dd><code>Add revision lookahead and generation control</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/ai-schedule-service/src/services/schedulingEngine.ts

<ul><li>Add <code>generateRevisions</code> optional flag to <code>TopicEstimate</code> interface to <br>control revision generation<br> <li> Add <code>REVISION_LOOKAHEAD_DAYS</code> constant set to 3 for forward search <br>capability<br> <li> Implement lookahead logic in <code>insertRevisionSessions</code> to search up to 3 <br>days forward when target day is full<br> <li> Respect <code>generateRevisions</code> flag to skip revision generation for <br>rescheduled revision workload</ul>


</details>


  </td>
  <td><a href="https://github.com/GauravSharmaCode/AI-Study-Planner/pull/9/files#diff-10638b79e20fd376b53c1bedb2e8271e612df31a6cac212dfdcb2e7f6c12ee35">+47/-26</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>studyPlanService.ts</strong><dd><code>Remove type casts and separate study/revision workload</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/ai-schedule-service/src/services/studyPlanService.ts

<ul><li>Import <code>StudySession</code> and <code>StudyPlan</code> types from Prisma instead of using <br>local type extensions<br> <li> Remove <code>ExtendedStudySession</code> and <code>ExtendedStudyPlan</code> local type <br>definitions<br> <li> Remove all <code>as any</code> casts throughout the file and use proper Prisma <br>types<br> <li> Separate workload tracking into <code>studyMinutes</code> and <code>revisionMinutes</code> in <br><code>reschedule</code> method<br> <li> Create separate topic estimates for study workload (with <br><code>generateRevisions: true</code>) and revision workload (with <br><code>generateRevisions: false</code>)</ul>


</details>


  </td>
  <td><a href="https://github.com/GauravSharmaCode/AI-Study-Planner/pull/9/files#diff-aa44869fd157921b426a76d33649562cefe4ae5201b8914ab63f7209277f0b7e">+56/-72</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

