### PR TITLE
perf: optimize session fetching in reschedule logic

### DIFF
--- a/services/ai-schedule-service/src/services/studyPlanService.ts
+++ b/services/ai-schedule-service/src/services/studyPlanService.ts
@@ -282,18 +282,28 @@ export class StudyPlanService {
     const func = "reschedule";
     logger.entry(func, { studyPlanId });
 
-    const plan = await this.prisma.studyPlan.findUnique({
-      where: { id: studyPlanId },
-      include: { sessions: true },
-    });
-
-    if (!plan) throw new Error(`Study plan not found: ${studyPlanId}`);
-    if (!plan.isActive) throw new Error(`Study plan is deactivated: ${studyPlanId}`);
-
     const now = new Date();
     const tomorrowMidnight = new Date(Date.UTC(
       now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1
     ));
+
+    const plan = await this.prisma.studyPlan.findUnique({
+      where: { id: studyPlanId },
+      include: {
+        sessions: {
+          where: {
+            OR: [
+              { status: 'skipped' },
+              { status: 'partial', completedMinutes: { not: null } },
+              { status: 'pending', date: { gte: tomorrowMidnight } },
+            ],
+          },
+        },
+      },
+    });
+
+    if (!plan) throw new Error(`Study plan not found: ${studyPlanId}`);
+    if (!plan.isActive) throw new Error(`Study plan is deactivated: ${studyPlanId}`);
 
     // Compute remaining workload from incomplete sessions
     let remainingMinutes = 0;


### PR DESCRIPTION
### **User description**
Relocated the `tomorrowMidnight` calculation and added a database-level filter to the Prisma `sessions` include in the `reschedule` method. This reduces the number of fetched sessions by excluding 'completed' sessions and 'pending' sessions before tomorrow, significantly reducing memory usage and network I/O for large study plans.


___

### **PR Type**
Enhancement


___

### **Description**
- Optimize session fetching by adding database-level filters

- Exclude completed and past-pending sessions from query

- Relocate tomorrowMidnight calculation before database query

- Reduce memory usage and network I/O for large study plans


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["reschedule method"] -->|"calculate tomorrowMidnight"| B["Date calculation"]
  B -->|"apply filters"| C["Prisma query"]
  C -->|"exclude completed<br/>exclude past-pending<br/>include skipped/partial"| D["Filtered sessions"]
  D -->|"reduced dataset"| E["Process remaining workload"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>studyPlanService.ts</strong><dd><code>Add database filters to reschedule session query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/ai-schedule-service/src/services/studyPlanService.ts

<ul><li>Moved <code>tomorrowMidnight</code> calculation before Prisma query execution<br> <li> Added database-level <code>where</code> filter to <code>sessions</code> include clause<br> <li> Filter includes sessions with status 'skipped', 'partial' with <br>completedMinutes, or 'pending' with date >= tomorrowMidnight<br> <li> Excludes 'completed' sessions and 'pending' sessions before tomorrow <br>from being fetched</ul>


</details>


  </td>
  <td><a href="https://github.com/GauravSharmaCode/AI-Study-Planner/pull/18/files#diff-aa44869fd157921b426a76d33649562cefe4ae5201b8914ab63f7209277f0b7e">+16/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

