### PR TITLE
Fix: Protect Session Routes and Cleanup Dead Code

### DIFF
--- a/services/ai-schedule-service/eslint.config.mjs
+++ b/services/ai-schedule-service/eslint.config.mjs
@@ -16,7 +16,7 @@ export default [
       parserOptions: {
         ecmaVersion: 2022,
         sourceType: 'module',
-        project: './tsconfig.json',
+        project: './tsconfig.eslint.json',
       },
     },
     plugins: {

--- a/services/ai-schedule-service/jest.config.json
+++ b/services/ai-schedule-service/jest.config.json
@@ -4,7 +4,8 @@
   "setupFilesAfterEnv": ["<rootDir>/tests/setup.ts"],
   "testMatch": [
     "<rootDir>/tests/**/*.test.ts",
-    "<rootDir>/tests/**/*.test.js"
+    "<rootDir>/tests/**/*.test.js",
+    "<rootDir>/src/**/__tests__/**/*.test.ts"
   ],
   "collectCoverageFrom": [
     "src/**/*.ts",

--- a/services/ai-schedule-service/src/routes/__tests__/sessionRoutes.test.ts
+++ b/services/ai-schedule-service/src/routes/__tests__/sessionRoutes.test.ts
@@ -1,3 +1,6 @@
+// Mock environment variables needed for module instantiation
+process.env.GOOGLE_GENAI_API_KEY = 'test-api-key';
+
 import sessionRoutes from '../sessionRoutes';
 import { protect } from '../../middleware/auth';
 

--- a/services/ai-schedule-service/src/routes/__tests__/sessionRoutes.test.ts
+++ b/services/ai-schedule-service/src/routes/__tests__/sessionRoutes.test.ts
@@ -1,0 +1,17 @@
+import express from 'express';
+import sessionRoutes from '../sessionRoutes';
+import { protect } from '../../middleware/auth';
+
+describe('Session Routes', () => {
+    it('should have the protect middleware applied', () => {
+        // Find the middleware in the router stack
+        // Express router stack items have a handle property which is the middleware function
+        const protectMiddleware = sessionRoutes.stack.find(
+            (layer: any) => layer.name === 'protect' || layer.handle === protect
+        );
+
+        expect(protectMiddleware).toBeDefined();
+        // Also verify it applies to all routes (no path restriction for use)
+        expect(protectMiddleware?.regexp.toString()).toContain('^\\/?(?=\\/|$)');
+    });
+});

--- a/services/ai-schedule-service/src/routes/__tests__/sessionRoutes.test.ts
+++ b/services/ai-schedule-service/src/routes/__tests__/sessionRoutes.test.ts
@@ -1,4 +1,3 @@
-import express from 'express';
 import sessionRoutes from '../sessionRoutes';
 import { protect } from '../../middleware/auth';
 
@@ -7,6 +6,7 @@ describe('Session Routes', () => {
         // Find the middleware in the router stack
         // Express router stack items have a handle property which is the middleware function
         const protectMiddleware = sessionRoutes.stack.find(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (layer: any) => layer.name === 'protect' || layer.handle === protect
         );
 

--- a/services/ai-schedule-service/src/routes/sessionRoutes.ts
+++ b/services/ai-schedule-service/src/routes/sessionRoutes.ts
@@ -1,12 +1,16 @@
 import express from 'express';
 import studyPlanController from '../controllers/studyPlanController';
 import { validateRequest } from '../middleware/validateRequest';
+import { protect } from '../middleware/auth';
 import {
     UpdateSessionStatusSchema,
     UpdateSessionRemarksSchema
 } from '../schemas';
 
 const router = express.Router();
+
+// All session routes require authentication
+router.use(protect);
 
 /**
  * PATCH /:id/status

--- a/services/ai-schedule-service/tsconfig.eslint.json
+++ b/services/ai-schedule-service/tsconfig.eslint.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
As part of Phase 6 frontend preparation, this branch updates `sessionRoutes` to mandate authentication using the `protect` middleware, ensuring all endpoints are secure. It also deletes `scheduleRoutes.ts`, an empty file that was confirmed to be unused dead code, and introduces a dedicated unit test inside `src/routes/__tests__/` to guarantee the middleware stays correctly applied in the stack.

---
*PR created automatically by Jules for task [11308699218441175782](https://jules.google.com/task/11308699218441175782) started by @GauravSharmaCode*