### PR TITLE
feat(web): add frontend pages — dashboard, timeline, analytics, components, hooks

### DIFF
--- a/apps/web/app/analytics/page.tsx
+++ b/apps/web/app/analytics/page.tsx
@@ -1,0 +1,189 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiGetJson } from "../lib/api";
+import AnalyticsChart from "../components/AnalyticsChart";
+
+interface AnalyticsData {
+  totalSessions: number;
+  completedSessions: number;
+  skippedSessions: number;
+  partialSessions: number;
+  pendingSessions: number;
+  totalPlannedMinutes: number;
+  totalCompletedMinutes: number;
+  completionPercentage: number;
+  daysRemaining: number;
+  remainingWorkloadMinutes: number;
+  isAtRisk: boolean;
+}
+
+interface Plan {
+  planId: string;
+  examName?: string;
+}
+
+export default function AnalyticsPage() {
+  const router = useRouter();
+  const [plan, setPlan] = useState<Plan | null>(null);
+  const [analytics, setAnalytics] = useState<AnalyticsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let token: string | null = null;
+    try {
+      token = (globalThis as any).localStorage?.getItem("auth_token") ?? null;
+    } catch {
+      token = null;
+    }
+    if (!token) {
+      router.push("/auth/login");
+      return;
+    }
+    fetchData();
+  }, [router]);
+
+  const fetchData = async () => {
+    try {
+      setLoading(true);
+      const { ok, data } = await apiGetJson("/api/v1/plans");
+      if (!ok) {
+        setError(data.message || "Failed to fetch plans");
+        return;
+      }
+      const activePlan = data.data?.find((p: any) => p.isActive);
+      if (activePlan) {
+        setPlan(activePlan);
+        const { ok: statOk, data: statData } = await apiGetJson(`/api/v1/plans/${activePlan.planId}/analytics`);
+        if (statOk) {
+          setAnalytics(statData.data);
+        } else {
+          setError("Failed to fetch analytics");
+        }
+      }
+    } catch (err) {
+      setError("Failed to load analytics");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading) {
+    return <div style={{ padding: "24px", textAlign: "center" }}>Loading analytics...</div>;
+  }
+
+  if (!plan || !analytics) {
+    return (
+      <div style={{ padding: "24px", textAlign: "center" }}>
+        <p>No active study plan found or no analytics available.</p>
+        <button
+          onClick={() => router.push("/dashboard")}
+          style={{
+            marginTop: "16px",
+            padding: "8px 16px",
+            backgroundColor: "#3b82f6",
+            color: "#fff",
+            border: "none",
+            borderRadius: "4px",
+            cursor: "pointer",
+          }}
+        >
+          Back to Dashboard
+        </button>
+      </div>
+    );
+  }
+
+  const formatHours = (mins: number) => (mins / 60).toFixed(1) + "h";
+
+  return (
+    <div style={{ padding: "24px", maxWidth: "800px", margin: "0 auto" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "24px" }}>
+        <button
+          onClick={() => router.push("/dashboard")}
+          style={{
+            padding: "8px 16px",
+            backgroundColor: "transparent",
+            color: "#3b82f6",
+            border: "none",
+            cursor: "pointer",
+          }}
+        >
+          ← Back to Dashboard
+        </button>
+      </div>
+
+      <h1 style={{ fontSize: "24px", fontWeight: 600, marginBottom: "8px" }}>Analytics & Progress</h1>
+      {plan.examName && <p style={{ color: "#6b7280", marginBottom: "24px" }}>{plan.examName}</p>}
+
+      {error && (
+        <div style={{ backgroundColor: "#fef2f2", color: "#dc2626", padding: "12px", borderRadius: "4px", marginBottom: "16px" }}>
+          {error}
+        </div>
+      )}
+
+      {analytics.isAtRisk && (
+        <div style={{ backgroundColor: "#fef2f2", color: "#b91c1c", padding: "16px", borderRadius: "8px", border: "1px solid #fca5a5", marginBottom: "24px", display: "flex", alignItems: "center", gap: "12px" }}>
+          <span style={{ fontSize: "20px" }}>⚠️</span>
+          <div>
+            <strong>Schedule at Risk</strong>
+            <p style={{ margin: 0, fontSize: "14px", marginTop: "4px" }}>
+              You are falling behind the required velocity to finish by your exam date. Consider increasing your daily study hours.
+            </p>
+          </div>
+        </div>
+      )}
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "24px", marginBottom: "32px" }}>
+        <div style={{ backgroundColor: "#f9fafb", padding: "24px", borderRadius: "8px", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
+          <h3 style={{ fontSize: "16px", fontWeight: 600, marginBottom: "24px", color: "#374151" }}>Overall Coverage</h3>
+          <AnalyticsChart
+            percentage={analytics.completionPercentage}
+            color={analytics.completionPercentage > 75 ? "#22c55e" : analytics.completionPercentage > 40 ? "#eab308" : "#3b82f6"}
+          />
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <div style={{ backgroundColor: "#f9fafb", padding: "16px", borderRadius: "8px" }}>
+            <div style={{ fontSize: "14px", color: "#6b7280" }}>Time Invested</div>
+            <div style={{ fontSize: "24px", fontWeight: 600, marginTop: "4px" }}>
+              {formatHours(analytics.totalCompletedMinutes)} <span style={{ fontSize: "14px", color: "#9ca3af", fontWeight: "normal" }}>/ {formatHours(analytics.totalPlannedMinutes)}</span>
+            </div>
+          </div>
+          
+          <div style={{ backgroundColor: "#f9fafb", padding: "16px", borderRadius: "8px" }}>
+            <div style={{ fontSize: "14px", color: "#6b7280" }}>Days Remaining</div>
+            <div style={{ fontSize: "24px", fontWeight: 600, marginTop: "4px", color: analytics.daysRemaining < 7 ? "#dc2626" : "inherit" }}>
+              {analytics.daysRemaining} days
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <h3 style={{ fontSize: "18px", fontWeight: 600, marginBottom: "16px" }}>Sessions Overview</h3>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))", gap: "16px" }}>
+        <div style={{ border: "1px solid #e5e7eb", padding: "16px", borderRadius: "8px", textAlign: "center" }}>
+          <div style={{ fontSize: "24px", fontWeight: 600 }}>{analytics.totalSessions}</div>
+          <div style={{ fontSize: "12px", color: "#6b7280", marginTop: "4px", textTransform: "uppercase" }}>Total</div>
+        </div>
+        <div style={{ border: "1px solid #bbf7d0", backgroundColor: "#f0fdf4", padding: "16px", borderRadius: "8px", textAlign: "center" }}>
+          <div style={{ fontSize: "24px", fontWeight: 600, color: "#166534" }}>{analytics.completedSessions}</div>
+          <div style={{ fontSize: "12px", color: "#166534", marginTop: "4px", textTransform: "uppercase" }}>Completed</div>
+        </div>
+        <div style={{ border: "1px solid #fef08a", backgroundColor: "#fefce8", padding: "16px", borderRadius: "8px", textAlign: "center" }}>
+          <div style={{ fontSize: "24px", fontWeight: 600, color: "#854d0e" }}>{analytics.partialSessions}</div>
+          <div style={{ fontSize: "12px", color: "#854d0e", marginTop: "4px", textTransform: "uppercase" }}>Partial</div>
+        </div>
+        <div style={{ border: "1px solid #fecaca", backgroundColor: "#fef2f2", padding: "16px", borderRadius: "8px", textAlign: "center" }}>
+          <div style={{ fontSize: "24px", fontWeight: 600, color: "#991b1b" }}>{analytics.skippedSessions}</div>
+          <div style={{ fontSize: "12px", color: "#991b1b", marginTop: "4px", textTransform: "uppercase" }}>Skipped</div>
+        </div>
+        <div style={{ border: "1px solid #e5e7eb", padding: "16px", borderRadius: "8px", textAlign: "center" }}>
+          <div style={{ fontSize: "24px", fontWeight: 600 }}>{analytics.pendingSessions}</div>
+          <div style={{ fontSize: "12px", color: "#6b7280", marginTop: "4px", textTransform: "uppercase" }}>Pending</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/components/AnalyticsChart.tsx
+++ b/apps/web/app/components/AnalyticsChart.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+interface AnalyticsChartProps {
+  percentage: number;
+  size?: number;
+  strokeWidth?: number;
+  color?: string;
+}
+
+export default function AnalyticsChart({
+  percentage,
+  size = 120,
+  strokeWidth = 12,
+  color = "#3b82f6",
+}: AnalyticsChartProps) {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = radius * 2 * Math.PI;
+  const strokeDashoffset = circumference - (percentage / 100) * circumference;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", position: "relative", width: size, height: size }}>
+      <svg height={size} width={size} style={{ transform: "rotate(-90deg)" }}>
+        <circle
+          stroke="#e5e7eb"
+          fill="transparent"
+          strokeWidth={strokeWidth}
+          r={radius}
+          cx={size / 2}
+          cy={size / 2}
+        />
+        <circle
+          stroke={color}
+          fill="transparent"
+          strokeWidth={strokeWidth}
+          strokeDasharray={circumference + " " + circumference}
+          style={{ strokeDashoffset, transition: "stroke-dashoffset 0.5s ease-in-out" }}
+          r={radius}
+          cx={size / 2}
+          cy={size / 2}
+          strokeLinecap="round"
+        />
+      </svg>
+      <div
+        style={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          fontSize: "24px",
+          fontWeight: "bold",
+          color: "#1f2937",
+        }}
+      >
+        {Math.round(percentage)}%
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/components/SessionCard.tsx
+++ b/apps/web/app/components/SessionCard.tsx
@@ -1,0 +1,237 @@
+"use client";
+import { useState } from "react";
+
+interface Session {
+  id: string;
+  topic: string;
+  subject?: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  plannedMinutes: number;
+  isRevision: boolean;
+  status: "PENDING" | "COMPLETED" | "PARTIAL" | "SKIPPED";
+  completedMinutes?: number;
+  remarks?: string;
+}
+
+interface SessionCardProps {
+  session: Session;
+  onComplete: (id: string) => void;
+  onPartial: (id: string, minutes: number) => void;
+  onSkip: (id: string) => void;
+  loading?: boolean;
+}
+
+export default function SessionCard({
+  session,
+  onComplete,
+  onPartial,
+  onSkip,
+  loading,
+}: SessionCardProps) {
+  const [showPartial, setShowPartial] = useState(false);
+  const [partialMinutes, setPartialMinutes] = useState("");
+
+  const handlePartial = () => {
+    const mins = parseInt(partialMinutes, 10);
+    if (mins > 0 && mins < session.plannedMinutes) {
+      onPartial(session.id, mins);
+      setShowPartial(false);
+      setPartialMinutes("");
+    }
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case "COMPLETED":
+        return "#22c55e";
+      case "PARTIAL":
+        return "#f59e0b";
+      case "SKIPPED":
+        return "#ef4444";
+      default:
+        return "#6b7280";
+    }
+  };
+
+  const formatTime = (time: string) => {
+    const [hours, minutes] = time.split(":");
+    const h = parseInt(hours || "0", 10);
+    const ampm = h >= 12 ? "PM" : "AM";
+    const h12 = h % 12 || 12;
+    return `${h12}:${minutes} ${ampm}`;
+  };
+
+  return (
+    <div
+      style={{
+        border: "1px solid #e5e7eb",
+        borderRadius: "8px",
+        padding: "16px",
+        marginBottom: "12px",
+        backgroundColor: session.status === "COMPLETED" ? "#f0fdf4" : "#fff",
+        opacity: session.status === "SKIPPED" ? 0.6 : 1,
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "start" }}>
+        <div style={{ flex: 1 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            <span style={{ fontWeight: 600, fontSize: "16px" }}>{session.topic}</span>
+            {session.isRevision && (
+              <span
+                style={{
+                  backgroundColor: "#e0f2fe",
+                  color: "#0369a1",
+                  padding: "2px 8px",
+                  borderRadius: "4px",
+                  fontSize: "12px",
+                }}
+              >
+                Revision
+              </span>
+            )}
+          </div>
+          {session.subject && (
+            <span
+              style={{
+                display: "inline-block",
+                marginTop: "4px",
+                backgroundColor: "#f3f4f6",
+                padding: "2px 8px",
+                borderRadius: "4px",
+                fontSize: "12px",
+                color: "#4b5563",
+              }}
+            >
+              {session.subject}
+            </span>
+          )}
+          <div style={{ marginTop: "8px", color: "#6b7280", fontSize: "14px" }}>
+            {formatTime(session.startTime)} - {formatTime(session.endTime)} ({session.plannedMinutes} min)
+          </div>
+        </div>
+        <span
+          style={{
+            backgroundColor: getStatusColor(session.status),
+            color: "#fff",
+            padding: "4px 12px",
+            borderRadius: "12px",
+            fontSize: "12px",
+            fontWeight: 500,
+          }}
+        >
+          {session.status}
+        </span>
+      </div>
+
+      {session.status === "PENDING" && (
+        <div style={{ marginTop: "12px", display: "flex", gap: "8px" }}>
+          <button
+            onClick={() => onComplete(session.id)}
+            disabled={loading}
+            style={{
+              padding: "6px 12px",
+              backgroundColor: "#22c55e",
+              color: "#fff",
+              border: "none",
+              borderRadius: "4px",
+              cursor: loading ? "not-allowed" : "pointer",
+              opacity: loading ? 0.6 : 1,
+            }}
+          >
+            Complete
+          </button>
+          <button
+            onClick={() => setShowPartial(!showPartial)}
+            disabled={loading}
+            style={{
+              padding: "6px 12px",
+              backgroundColor: "#f59e0b",
+              color: "#fff",
+              border: "none",
+              borderRadius: "4px",
+              cursor: loading ? "not-allowed" : "pointer",
+              opacity: loading ? 0.6 : 1,
+            }}
+          >
+            Partial
+          </button>
+          <button
+            onClick={() => onSkip(session.id)}
+            disabled={loading}
+            style={{
+              padding: "6px 12px",
+              backgroundColor: "#ef4444",
+              color: "#fff",
+              border: "none",
+              borderRadius: "4px",
+              cursor: loading ? "not-allowed" : "pointer",
+              opacity: loading ? 0.6 : 1,
+            }}
+          >
+            Skip
+          </button>
+        </div>
+      )}
+
+      {showPartial && (
+        <div style={{ marginTop: "12px", display: "flex", gap: "8px", alignItems: "center" }}>
+          <input
+            type="number"
+            value={partialMinutes}
+            onChange={(e: any) => setPartialMinutes(e.target.value)}
+            placeholder="Minutes"
+            min="1"
+            max={session.plannedMinutes - 1}
+            style={{
+              padding: "6px 8px",
+              border: "1px solid #d1d5db",
+              borderRadius: "4px",
+              width: "80px",
+            }}
+          />
+          <button
+            onClick={handlePartial}
+            style={{
+              padding: "6px 12px",
+              backgroundColor: "#f59e0b",
+              color: "#fff",
+              border: "none",
+              borderRadius: "4px",
+            }}
+          >
+            Save
+          </button>
+          <button
+            onClick={() => {
+              setShowPartial(false);
+              setPartialMinutes("");
+            }}
+            style={{
+              padding: "6px 12px",
+              backgroundColor: "transparent",
+              color: "#6b7280",
+              border: "1px solid #d1d5db",
+              borderRadius: "4px",
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {session.status === "PARTIAL" && session.completedMinutes && (
+        <div style={{ marginTop: "8px", fontSize: "12px", color: "#f59e0b" }}>
+          Completed: {session.completedMinutes} minutes
+        </div>
+      )}
+
+      {session.remarks && (
+        <div style={{ marginTop: "8px", fontSize: "12px", color: "#6b7280", fontStyle: "italic" }}>
+          Note: {session.remarks}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -1,0 +1,228 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import SessionCard from "../components/SessionCard";
+import { apiGetJson, apiPatchJson } from "../lib/api";
+import { useRescheduleStatus } from "../hooks/useRescheduleStatus";
+
+interface Session {
+  id: string;
+  topic: string;
+  subject?: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  plannedMinutes: number;
+  isRevision: boolean;
+  status: "PENDING" | "COMPLETED" | "PARTIAL" | "SKIPPED";
+  completedMinutes?: number;
+  remarks?: string;
+}
+
+interface Plan {
+  planId: string;
+  version: number;
+  examName?: string;
+  subjects: string[];
+  sessions: Session[];
+}
+
+export default function DashboardPage() {
+  const router = useRouter();
+  const [plan, setPlan] = useState<Plan | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [updatingSession, setUpdatingSession] = useState<string | null>(null);
+
+  const fetchPlan = async () => {
+    try {
+      setLoading(true);
+      const { ok, data } = await apiGetJson("/api/v1/plans");
+      if (!ok) {
+        setError(data.message || "Failed to fetch plans");
+        return;
+      }
+      const activePlan = data.data?.find((p: any) => p.isActive);
+      if (activePlan) {
+        const { ok: planOk, data: planData } = await apiGetJson(`/api/v1/plans/${activePlan.planId}`);
+        if (planOk) {
+          setPlan(planData.data);
+        }
+      }
+    } catch (err) {
+      setError("Failed to load plan");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const { isRescheduling, triggerReschedulePoll } = useRescheduleStatus(
+    plan?.planId,
+    plan?.version,
+    fetchPlan
+  );
+
+  useEffect(() => {
+    let token: string | null = null;
+    try {
+      token = (globalThis as any).localStorage?.getItem("auth_token") ?? null;
+    } catch {
+      token = null;
+    }
+    if (!token) {
+      router.push("/auth/login");
+      return;
+    }
+    fetchPlan();
+  }, [router]);
+
+  const getTodaySessions = (): Session[] => {
+    if (!plan?.sessions) return [];
+    const today = new Date().toISOString().split("T")[0] || "";
+    return plan.sessions.filter((s) => s.date.startsWith(today));
+  };
+
+  const handleStatusUpdate = async (sessionId: string, status: string, completedMinutes?: number) => {
+    try {
+      setUpdatingSession(sessionId);
+      const body: any = { status };
+      if (completedMinutes !== undefined) {
+        body.completedMinutes = completedMinutes;
+      }
+      const { ok } = await apiPatchJson(`/api/v1/sessions/${sessionId}/status`, body);
+      if (ok) {
+        if (status === "PARTIAL" || status === "SKIPPED") {
+          // Trigger the polling hook for async rebalancing
+          triggerReschedulePoll();
+        } else {
+          await fetchPlan();
+        }
+      }
+    } catch (err) {
+      setError("Failed to update session");
+    } finally {
+      setUpdatingSession(null);
+    }
+  };
+
+  const todaySessions = getTodaySessions();
+  const completedCount = todaySessions.filter((s) => s.status === "COMPLETED").length;
+
+  if (loading && !plan) {
+    return (
+      <div style={{ padding: "24px", textAlign: "center" }}>
+        <p>Loading your study plan...</p>
+      </div>
+    );
+  }
+
+  if (!plan) {
+    return (
+      <div style={{ padding: "24px", textAlign: "center" }}>
+        <p>No active study plan found.</p>
+        <button
+          onClick={() => router.push("/wizard")}
+          style={{
+            marginTop: "16px",
+            padding: "8px 16px",
+            backgroundColor: "#3b82f6",
+            color: "#fff",
+            border: "none",
+            borderRadius: "4px",
+            cursor: "pointer",
+          }}
+        >
+          Create Plan
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: "24px", maxWidth: "800px", margin: "0 auto" }}>
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+      
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "8px" }}>
+        <h1 style={{ fontSize: "24px", fontWeight: 600 }}>Today&apos;s Study Plan</h1>
+        <button
+          onClick={() => router.push("/analytics")}
+          style={{ padding: "6px 12px", backgroundColor: "#f3f4f6", border: "none", borderRadius: "4px", cursor: "pointer", fontSize: "14px" }}
+        >
+          View Analytics
+        </button>
+      </div>
+      
+      {plan.examName && (
+        <p style={{ color: "#6b7280", marginBottom: "24px" }}>{plan.examName}</p>
+      )}
+
+      {isRescheduling && (
+        <div style={{ backgroundColor: "#eff6ff", color: "#1d4ed8", padding: "12px", borderRadius: "8px", marginBottom: "24px", display: "flex", alignItems: "center", gap: "12px" }}>
+          <div style={{ width: "16px", height: "16px", border: "2px solid #93c5fd", borderTopColor: "#1d4ed8", borderRadius: "50%", animation: "spin 1s linear infinite" }}></div>
+          <span style={{ fontWeight: 500 }}>AI is rebalancing your schedule in the background...</span>
+        </div>
+      )}
+
+      <div
+        style={{
+          backgroundColor: "#f9fafb",
+          padding: "16px",
+          borderRadius: "8px",
+          marginBottom: "24px",
+        }}
+      >
+        <div style={{ fontSize: "14px", color: "#6b7280" }}>Today&apos;s Progress</div>
+        <div style={{ fontSize: "24px", fontWeight: 600, marginTop: "4px" }}>
+          {completedCount} / {todaySessions.length} sessions completed
+        </div>
+      </div>
+
+      {error && (
+        <div
+          style={{
+            backgroundColor: "#fef2f2",
+            color: "#dc2626",
+            padding: "12px",
+            borderRadius: "4px",
+            marginBottom: "16px",
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {todaySessions.length === 0 ? (
+        <p style={{ color: "#6b7280", textAlign: "center", padding: "32px" }}>
+          No sessions scheduled for today.
+        </p>
+      ) : (
+        todaySessions.map((session) => (
+          <SessionCard
+            key={session.id}
+            session={session}
+            onComplete={(id) => handleStatusUpdate(id, "COMPLETED")}
+            onPartial={(id, mins) => handleStatusUpdate(id, "PARTIAL", mins)}
+            onSkip={(id) => handleStatusUpdate(id, "SKIPPED")}
+            loading={updatingSession === session.id || isRescheduling}
+          />
+        ))
+      )}
+
+      <div style={{ marginTop: "32px", textAlign: "center" }}>
+        <button
+          onClick={() => router.push("/timeline")}
+          style={{
+            padding: "8px 16px",
+            backgroundColor: "transparent",
+            color: "#3b82f6",
+            border: "1px solid #3b82f6",
+            borderRadius: "4px",
+            cursor: "pointer",
+          }}
+        >
+          View Full Timeline
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/hooks/useRescheduleStatus.ts
+++ b/apps/web/app/hooks/useRescheduleStatus.ts
@@ -1,0 +1,36 @@
+"use client";
+import { useState, useEffect, useCallback } from "react";
+import { apiGetJson } from "../lib/api";
+
+export function useRescheduleStatus(
+  planId: string | undefined,
+  currentVersion: number | undefined,
+  onRescheduled: () => void
+) {
+  const [isRescheduling, setIsRescheduling] = useState(false);
+
+  useEffect(() => {
+    if (!planId || currentVersion === undefined || !isRescheduling) return;
+
+    const intervalId = setInterval(async () => {
+      try {
+        const { ok, data } = await apiGetJson(`/api/v1/plans/${planId}`);
+        // If version has incremented, background job is finished
+        if (ok && data?.data?.version !== undefined && data.data.version > currentVersion) {
+          setIsRescheduling(false);
+          onRescheduled(); // Call callback to trigger a full refresh in the parent component
+        }
+      } catch (err) {
+        console.error("Failed to poll for reschedule status", err);
+      }
+    }, 3000); // Poll every 3 seconds
+
+    return () => clearInterval(intervalId);
+  }, [planId, currentVersion, isRescheduling, onRescheduled]);
+
+  const triggerReschedulePoll = useCallback(() => {
+    setIsRescheduling(true);
+  }, []);
+
+  return { isRescheduling, triggerReschedulePoll };
+}

--- a/apps/web/app/lib/api.ts
+++ b/apps/web/app/lib/api.ts
@@ -11,7 +11,7 @@ export async function apiFetch(input: any, init: any = {}) {
   return fetch(input, merged);
 }
 
-export async function apiPostJson<T = any>(url: string, body: any) {
+export async function apiPostJson(url: string, body: any): Promise<{ok: boolean; data: any}> {
   const res = await apiFetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -21,7 +21,7 @@ export async function apiPostJson<T = any>(url: string, body: any) {
   return { ok: res.ok, data };
 }
 
-export async function apiPutJson<T = any>(url: string, body: any) {
+export async function apiPutJson(url: string, body: any): Promise<{ok: boolean; data: any}> {
   const res = await apiFetch(url, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
@@ -31,7 +31,17 @@ export async function apiPutJson<T = any>(url: string, body: any) {
   return { ok: res.ok, data };
 }
 
-export async function apiGetJson<T = any>(url: string) {
+export async function apiPatchJson(url: string, body: any): Promise<{ok: boolean; data: any}> {
+  const res = await apiFetch(url, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  return { ok: res.ok, data };
+}
+
+export async function apiGetJson(url: string): Promise<{ok: boolean; data: any}> {
   const res = await apiFetch(url, { method: "GET" });
   const data = await res.json();
   return { ok: res.ok, data };

--- a/apps/web/app/timeline/page.tsx
+++ b/apps/web/app/timeline/page.tsx
@@ -1,0 +1,293 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import SessionCard from "../components/SessionCard";
+import { apiGetJson, apiPatchJson } from "../lib/api";
+import { useRescheduleStatus } from "../hooks/useRescheduleStatus";
+
+interface Session {
+  id: string;
+  topic: string;
+  subject?: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  plannedMinutes: number;
+  isRevision: boolean;
+  status: "PENDING" | "COMPLETED" | "PARTIAL" | "SKIPPED";
+  completedMinutes?: number;
+  remarks?: string;
+}
+
+interface Plan {
+  planId: string;
+  version: number;
+  examName?: string;
+  sessions: Session[];
+}
+
+export default function TimelinePage() {
+  const router = useRouter();
+  const [plan, setPlan] = useState<Plan | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [updatingSession, setUpdatingSession] = useState<string | null>(null);
+  const [selectedDate, setSelectedDate] = useState<string>(new Date().toISOString().split("T")[0] || "");
+
+  const fetchPlan = async () => {
+    try {
+      setLoading(true);
+      const { ok, data } = await apiGetJson("/api/v1/plans");
+      if (!ok) {
+        setError(data.message || "Failed to fetch plans");
+        return;
+      }
+      const activePlan = data.data?.find((p: any) => p.isActive);
+      if (activePlan) {
+        const { ok: planOk, data: planData } = await apiGetJson(`/api/v1/plans/${activePlan.planId}`);
+        if (planOk) {
+          setPlan(planData.data);
+        }
+      }
+    } catch (err) {
+      setError("Failed to load plan");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const { isRescheduling, triggerReschedulePoll } = useRescheduleStatus(
+    plan?.planId,
+    plan?.version,
+    fetchPlan
+  );
+
+  useEffect(() => {
+    let token: string | null = null;
+    try {
+      token = (globalThis as any).localStorage?.getItem("auth_token") ?? null;
+    } catch {
+      token = null;
+    }
+    if (!token) {
+      router.push("/auth/login");
+      return;
+    }
+    fetchPlan();
+  }, [router]);
+
+  const getSessionsForDate = (date: string): Session[] => {
+    if (!plan?.sessions) return [];
+    return plan.sessions.filter((s) => s.date.startsWith(date));
+  };
+
+  const handleStatusUpdate = async (sessionId: string, status: string, completedMinutes?: number) => {
+    try {
+      setUpdatingSession(sessionId);
+      const body: any = { status };
+      if (completedMinutes !== undefined) {
+        body.completedMinutes = completedMinutes;
+      }
+      const { ok } = await apiPatchJson(`/api/v1/sessions/${sessionId}/status`, body);
+      if (ok) {
+        if (status === "PARTIAL" || status === "SKIPPED") {
+          triggerReschedulePoll();
+        } else {
+          await fetchPlan();
+        }
+      }
+    } catch (err) {
+      setError("Failed to update session");
+    } finally {
+      setUpdatingSession(null);
+    }
+  };
+
+  const navigateDate = (days: number) => {
+    const current = new Date(selectedDate!);
+    current.setDate(current.getDate() + days);
+    setSelectedDate(current.toISOString().split("T")[0] || "");
+  };
+
+  const formatDateDisplay = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return date.toLocaleDateString("en-US", {
+      weekday: "long",
+      month: "long",
+      day: "numeric",
+    });
+  };
+
+  const isToday = selectedDate === (new Date().toISOString().split("T")[0] || "");
+
+  const sessions = getSessionsForDate(selectedDate);
+  const completedCount = sessions.filter((s) => s.status === "COMPLETED").length;
+
+  if (loading && !plan) {
+    return (
+      <div style={{ padding: "24px", textAlign: "center" }}>
+        <p>Loading your study plan...</p>
+      </div>
+    );
+  }
+
+  if (!plan) {
+    return (
+      <div style={{ padding: "24px", textAlign: "center" }}>
+        <p>No active study plan found.</p>
+        <button
+          onClick={() => router.push("/wizard")}
+          style={{
+            marginTop: "16px",
+            padding: "8px 16px",
+            backgroundColor: "#3b82f6",
+            color: "#fff",
+            border: "none",
+            borderRadius: "4px",
+            cursor: "pointer",
+          }}
+        >
+          Create Plan
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: "24px", maxWidth: "800px", margin: "0 auto" }}>
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "24px" }}>
+        <button
+          onClick={() => router.push("/dashboard")}
+          style={{
+            padding: "8px 16px",
+            backgroundColor: "transparent",
+            color: "#3b82f6",
+            border: "none",
+            cursor: "pointer",
+          }}
+        >
+          ← Back to Dashboard
+        </button>
+        <button
+          onClick={() => router.push("/analytics")}
+          style={{ padding: "6px 12px", backgroundColor: "#f3f4f6", border: "none", borderRadius: "4px", cursor: "pointer", fontSize: "14px" }}
+        >
+          Analytics
+        </button>
+      </div>
+
+      <h1 style={{ fontSize: "24px", fontWeight: 600, marginBottom: "8px" }}>Timeline</h1>
+      {plan.examName && (
+        <p style={{ color: "#6b7280", marginBottom: "24px" }}>{plan.examName}</p>
+      )}
+
+      {isRescheduling && (
+        <div style={{ backgroundColor: "#eff6ff", color: "#1d4ed8", padding: "12px", borderRadius: "8px", marginBottom: "24px", display: "flex", alignItems: "center", gap: "12px" }}>
+          <div style={{ width: "16px", height: "16px", border: "2px solid #93c5fd", borderTopColor: "#1d4ed8", borderRadius: "50%", animation: "spin 1s linear infinite" }}></div>
+          <span style={{ fontWeight: 500 }}>AI is rebalancing your schedule in the background...</span>
+        </div>
+      )}
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          backgroundColor: "#f9fafb",
+          padding: "16px",
+          borderRadius: "8px",
+          marginBottom: "24px",
+        }}
+      >
+        <button
+          onClick={() => navigateDate(-1)}
+          style={{
+            padding: "8px 16px",
+            backgroundColor: "#fff",
+            border: "1px solid #d1d5db",
+            borderRadius: "4px",
+            cursor: "pointer",
+          }}
+        >
+          ← Previous
+        </button>
+        <div style={{ textAlign: "center" }}>
+          <div style={{ fontSize: "18px", fontWeight: 600 }}>{formatDateDisplay(selectedDate)}</div>
+          {isToday && (
+            <span
+              style={{
+                backgroundColor: "#3b82f6",
+                color: "#fff",
+                padding: "2px 8px",
+                borderRadius: "4px",
+                fontSize: "12px",
+              }}
+            >
+              Today
+            </span>
+          )}
+          <input
+            type="date"
+            value={selectedDate}
+            onChange={(e: any) => setSelectedDate(e.target.value)}
+            style={{
+              marginTop: "8px",
+              padding: "4px 8px",
+              border: "1px solid #d1d5db",
+              borderRadius: "4px",
+            }}
+          />
+        </div>
+        <button
+          onClick={() => navigateDate(1)}
+          style={{
+            padding: "8px 16px",
+            backgroundColor: "#fff",
+            border: "1px solid #d1d5db",
+            borderRadius: "4px",
+            cursor: "pointer",
+          }}
+        >
+          Next →
+        </button>
+      </div>
+
+      {error && (
+        <div
+          style={{
+            backgroundColor: "#fef2f2",
+            color: "#dc2626",
+            padding: "12px",
+            borderRadius: "4px",
+            marginBottom: "16px",
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {sessions.length === 0 ? (
+        <p style={{ color: "#6b7280", textAlign: "center", padding: "32px" }}>
+          No sessions scheduled for this date.
+        </p>
+      ) : (
+        <>
+          <div style={{ marginBottom: "16px", color: "#6b7280" }}>
+            {completedCount} / {sessions.length} completed
+          </div>
+          {sessions.map((session) => (
+            <SessionCard
+              key={session.id}
+              session={session}
+              onComplete={(id) => handleStatusUpdate(id, "COMPLETED")}
+              onPartial={(id, mins) => handleStatusUpdate(id, "PARTIAL", mins)}
+              onSkip={(id) => handleStatusUpdate(id, "SKIPPED")}
+              loading={updatingSession === session.id || isRescheduling}
+            />
+          ))}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,14 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: 'http://localhost:8080/api/:path*',
+      },
+    ];
+  },
+};
+
+export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "cross-env NODE_ENV=production next build",
     "start": "next start"
   },
   "dependencies": {
@@ -14,6 +14,8 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "@types/react": "19.2.14"
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "cross-env": "^7.0.3"
   }
 }


### PR DESCRIPTION
## Summary

Adds all previously untracked frontend pages and components to the `apps/web` Next.js app.

### New Files
- `app/dashboard/page.tsx` — Dashboard with today's sessions, status update actions
- `app/timeline/page.tsx` — Day-by-day timeline view with date navigation
- `app/analytics/page.tsx` — Analytics overview with study stats
- `app/components/SessionCard.tsx` — Reusable session card with Complete / Partial / Skip actions
- `app/components/AnalyticsChart.tsx` — Analytics chart component
- `app/hooks/useRescheduleStatus.ts` — Hook for polling AI reschedule status
- `apps/web/next.config.mjs` — Next.js config with API proxy rewrites

### Modified Files
- `app/lib/api.ts` — Added `apiPatchJson` export; explicit return types on all API helpers
- `package.json` — Added `cross-env` dev dependency

### Testing
- ✅ Production build passes (`next build`) — all 13 routes compiled cleanly
- ✅ Dev server runs on `localhost:3002`
- ✅ Public routes (`/`, `/auth/login`) load correctly
- ✅ Protected routes (`/dashboard`, `/timeline`, `/analytics`) correctly redirect to login
- ❌ `test-login.js` and `test-frontend.bat` excluded from commit intentionally