### PR TITLE
Fix frontend out of sync with backend (Wizard and Session Status)

### DIFF
--- a/apps/web/app/components/SessionCard.tsx
+++ b/apps/web/app/components/SessionCard.tsx
@@ -11,7 +11,7 @@ interface Session {
   endTime: string;
   plannedMinutes: number;
   isRevision: boolean;
-  status: "PENDING" | "COMPLETED" | "PARTIAL" | "SKIPPED";
+  status: "pending" | "completed" | "partial" | "skipped";
   completedMinutes?: number;
   remarks?: string;
 }
@@ -45,11 +45,11 @@ export default function SessionCard({
 
   const getStatusStyle = (status: string) => {
     switch (status) {
-      case "COMPLETED":
+      case "completed":
         return { backgroundColor: "rgba(34, 197, 94, 0.1)", color: "var(--status-success)" };
-      case "PARTIAL":
+      case "partial":
         return { backgroundColor: "rgba(245, 158, 11, 0.1)", color: "var(--status-warning)" };
-      case "SKIPPED":
+      case "skipped":
         return { backgroundColor: "rgba(239, 68, 68, 0.1)", color: "var(--status-error)" };
       default:
         return { backgroundColor: "var(--bg-primary)", color: "var(--text-secondary)" };
@@ -63,8 +63,8 @@ export default function SessionCard({
       className="claude-card"
       style={{
         marginBottom: "12px",
-        opacity: session.status === "SKIPPED" ? 0.6 : 1,
-        borderLeft: session.status === "COMPLETED" ? "4px solid var(--status-success)" : "1px solid var(--border-subtle)",
+        opacity: session.status === "skipped" ? 0.6 : 1,
+        borderLeft: session.status === "completed" ? "4px solid var(--status-success)" : "1px solid var(--border-subtle)",
       }}
     >
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "start" }}>
@@ -108,7 +108,7 @@ export default function SessionCard({
         </span>
       </div>
 
-      {session.status === "PENDING" && (
+      {session.status === "pending" && (
         <div style={{ marginTop: "1.5rem", display: "flex", gap: "10px" }}>
           <button
             className="claude-button"
@@ -164,7 +164,7 @@ export default function SessionCard({
         </div>
       )}
 
-      {session.status === "PARTIAL" && session.completedMinutes && (
+      {session.status === "partial" && session.completedMinutes && (
         <div style={{ marginTop: "12px", fontSize: "0.875rem", color: "var(--status-warning)", fontWeight: 500 }}>
           ✓ Completed {session.completedMinutes} minutes
         </div>

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -15,7 +15,7 @@ interface Session {
   endTime: string;
   plannedMinutes: number;
   isRevision: boolean;
-  status: "PENDING" | "COMPLETED" | "PARTIAL" | "SKIPPED";
+  status: "pending" | "completed" | "partial" | "skipped";
   completedMinutes?: number;
   remarks?: string;
 }
@@ -95,7 +95,7 @@ export default function DashboardPage() {
       }
       const { ok } = await apiPatchJson(`/api/v1/sessions/${sessionId}/status`, body);
       if (ok) {
-        if (status === "PARTIAL" || status === "SKIPPED") {
+        if (status === "partial" || status === "skipped") {
           triggerReschedulePoll();
         } else {
           await fetchPlan();
@@ -109,7 +109,7 @@ export default function DashboardPage() {
   };
 
   const todaySessions = getTodaySessions();
-  const completedCount = todaySessions.filter((s) => s.status === "COMPLETED").length;
+  const completedCount = todaySessions.filter((s) => s.status === "completed").length;
 
   if (loading && !plan) {
     return (
@@ -183,9 +183,9 @@ export default function DashboardPage() {
             <SessionCard
               key={session.id}
               session={session}
-              onComplete={(id) => handleStatusUpdate(id, "COMPLETED")}
-              onPartial={(id, mins) => handleStatusUpdate(id, "PARTIAL", mins)}
-              onSkip={(id) => handleStatusUpdate(id, "SKIPPED")}
+              onComplete={(id) => handleStatusUpdate(id, "completed")}
+              onPartial={(id, mins) => handleStatusUpdate(id, "partial", mins)}
+              onSkip={(id) => handleStatusUpdate(id, "skipped")}
               loading={updatingSession === session.id || isRescheduling}
             />
           ))

--- a/apps/web/app/timeline/page.tsx
+++ b/apps/web/app/timeline/page.tsx
@@ -15,7 +15,7 @@ interface Session {
   endTime: string;
   plannedMinutes: number;
   isRevision: boolean;
-  status: "PENDING" | "COMPLETED" | "PARTIAL" | "SKIPPED";
+  status: "pending" | "completed" | "partial" | "skipped";
   completedMinutes?: number;
   remarks?: string;
 }
@@ -94,7 +94,7 @@ export default function TimelinePage() {
       }
       const { ok } = await apiPatchJson(`/api/v1/sessions/${sessionId}/status`, body);
       if (ok) {
-        if (status === "PARTIAL" || status === "SKIPPED") {
+        if (status === "partial" || status === "skipped") {
           triggerReschedulePoll();
         } else {
           await fetchPlan();
@@ -116,7 +116,7 @@ export default function TimelinePage() {
   };
 
   const sessions = getSessionsForDate(selectedDate);
-  const completedCount = sessions.filter((s) => s.status === "COMPLETED").length;
+  const completedCount = sessions.filter((s) => s.status === "completed").length;
 
   if (loading && !plan) {
     return (
@@ -212,9 +212,9 @@ export default function TimelinePage() {
               <SessionCard
                 key={session.id}
                 session={session}
-                onComplete={(id) => handleStatusUpdate(id, "COMPLETED")}
-                onPartial={(id, mins) => handleStatusUpdate(id, "PARTIAL", mins)}
-                onSkip={(id) => handleStatusUpdate(id, "SKIPPED")}
+                onComplete={(id) => handleStatusUpdate(id, "completed")}
+                onPartial={(id, mins) => handleStatusUpdate(id, "partial", mins)}
+                onSkip={(id) => handleStatusUpdate(id, "skipped")}
                 loading={updatingSession === session.id || isRescheduling}
               />
             ))}

--- a/apps/web/app/wizard/step2/page.tsx
+++ b/apps/web/app/wizard/step2/page.tsx
@@ -9,6 +9,8 @@ export default function WizardStep2() {
   const router = useRouter();
   const [step1, setStep1] = useState<Step1Data | null>(null);
   const [rawSubjects, setRawSubjects] = useState("");
+  const [availableHoursPerDay, setAvailableHoursPerDay] = useState(4);
+  const [preferredStartTime, setPreferredStartTime] = useState("08:00");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -34,10 +36,10 @@ export default function WizardStep2() {
 
     const payload = {
       subjects,
-      availableHoursPerDay: 4,
+      availableHoursPerDay: Number(availableHoursPerDay),
       targetCompletionDate: step1.targetDate,
       examName: step1.examName,
-      preferredStartTime: "08:00",
+      preferredStartTime,
     };
 
     try {
@@ -65,7 +67,7 @@ export default function WizardStep2() {
           <p style={{ color: "var(--text-secondary)", fontSize: "0.875rem" }}>What subjects or areas are you covering?</p>
         </div>
 
-        <div style={{ marginBottom: "32px" }}>
+        <div style={{ marginBottom: "24px" }}>
           <label className="claude-label">List Subjects</label>
           <textarea
             className="claude-input"
@@ -76,6 +78,33 @@ export default function WizardStep2() {
             required
           />
           <p style={{ marginTop: "8px", fontSize: "0.75rem", color: "var(--text-muted)" }}>Separate subjects with commas. Our AI will break these down into study units.</p>
+        </div>
+
+        <div style={{ marginBottom: "24px" }}>
+          <label className="claude-label">Available Study Hours per Day</label>
+          <input
+            type="number"
+            className="claude-input"
+            min={0.5}
+            max={12}
+            step={0.5}
+            value={availableHoursPerDay}
+            onChange={(e: any) => setAvailableHoursPerDay(e.target.value)}
+            required
+          />
+          <p style={{ marginTop: "8px", fontSize: "0.75rem", color: "var(--text-muted)" }}>How many hours can you dedicate to studying each day?</p>
+        </div>
+
+        <div style={{ marginBottom: "32px" }}>
+          <label className="claude-label">Preferred Start Time</label>
+          <input
+            type="time"
+            className="claude-input"
+            value={preferredStartTime}
+            onChange={(e: any) => setPreferredStartTime(e.target.value)}
+            required
+          />
+          <p style={{ marginTop: "8px", fontSize: "0.75rem", color: "var(--text-muted)" }}>When do you usually start studying? (e.g. 08:00)</p>
         </div>
 
         {error && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2256,7 +2256,7 @@ caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001759:
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001764.tgz"
   integrity sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2387,6 +2387,19 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+concurrently@^9.1.0:
+  version "9.2.0"
+  resolved "https://registry.npmjs.org/concurrently/-/concurrently-9.2.0.tgz"
+  integrity sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==
+  dependencies:
+    chalk "^4.1.2"
+    lodash "^4.17.21"
+    rxjs "^7.8.1"
+    shell-quote "^1.8.1"
+    supports-color "^8.1.1"
+    tree-kill "^1.2.2"
+    yargs "^17.7.2"
 
 content-disposition@~0.5.4:
   version "0.5.4"
@@ -4551,6 +4564,11 @@ prelude-ls@^1.2.1:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+prettier@^3.4.2:
+  version "3.6.2"
+  resolved "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz"
+  integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==
+
 pretty-format@^29.0.0, pretty-format@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz"
@@ -4779,6 +4797,13 @@ rimraf@^6.0.1, rimraf@^6.1.2:
     glob "^13.0.0"
     package-json-from-dist "^1.0.1"
 
+rxjs@^7.8.1:
+  version "7.8.2"
+  resolved "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz"
+  integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-buffer@^5.0.1, safe-buffer@~5.2.0, safe-buffer@5.2.1:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
@@ -4881,6 +4906,11 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+shell-quote@^1.8.1:
+  version "1.8.3"
+  resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz"
+  integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
 
 side-channel-list@^1.0.0:
   version "1.0.0"
@@ -5151,6 +5181,13 @@ supports-color@^8.0.0:
   dependencies:
     has-flag "^4.0.0"
 
+supports-color@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
+  dependencies:
+    has-flag "^4.0.0"
+
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
@@ -5282,7 +5319,7 @@ tsconfig@^7.0.0:
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
-tslib@^2.4.0, tslib@2.8.1:
+tslib@^2.1.0, tslib@^2.4.0, tslib@2.8.1:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -5572,7 +5609,7 @@ yargs-parser@^21.1.1:
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
-yargs@^17.3.1:
+yargs@^17.3.1, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
Syncs the frontend with the backend schemas.

Specifically:
- The backend required `availableHoursPerDay` and `preferredStartTime` when creating a study plan via `/api/v1/plans/generate`, but the frontend hardcoded `availableHoursPerDay` to `4` and `preferredStartTime` to `08:00`. This caused plan generation to fail when users inputted subjects that would take more than 4 hours a day to study. The wizard Step 2 now properly asks for these two values and sends them to the backend.
- The backend validated session status strings as lowercase values (`pending`, `completed`, `partial`, `skipped`), but the frontend sent and managed them as UPPERCASE strings. This caused status updates to fail. The frontend now consistently uses lowercase status strings for session status.

---
*PR created automatically by Jules for task [1249442424003082257](https://jules.google.com/task/1249442424003082257) started by @GauravSharmaCode*